### PR TITLE
Relax require to use an alias rather than a hard coded path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class aptly (
   file { $config_file:
     ensure  => file,
     content => $config_file_contents,
+    alias   => 'aptly_config_file',
   }
 
   $aptly_cmd = "/usr/bin/aptly -config ${config_file}"

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -129,7 +129,7 @@ define aptly::mirror (
   if $key.empty {
     $exec_aptly_mirror_create_require = [
       Package['aptly'],
-      File['/etc/aptly.conf'],
+      File['aptly_config_file'],
     ]
   }else{
     exec { "aptly_mirror_gpg-${title}":
@@ -141,7 +141,7 @@ define aptly::mirror (
 
     $exec_aptly_mirror_create_require = [
       Package['aptly'],
-      File['/etc/aptly.conf'],
+      File['aptly_config_file'],
       Exec["aptly_mirror_gpg-${title}"],
     ]
   }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -61,7 +61,7 @@ define aptly::repo(
     user    => $::aptly::user,
     require => [
       Package['aptly'],
-      File['/etc/aptly.conf'],
+      File['aptly_config_file'],
     ],
   }
 }

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -43,7 +43,7 @@ describe 'aptly::mirror' do
                                                                       user: 'root',
                                                                       require: [
                                                                         'Package[aptly]',
-                                                                        'File[/etc/aptly.conf]',
+                                                                        'File[aptly_config_file]',
                                                                         'Exec[aptly_mirror_gpg-example]'
                                                                       ])
     }
@@ -71,7 +71,7 @@ describe 'aptly::mirror' do
                                                                         user: 'root',
                                                                         require: [
                                                                           'Package[aptly]',
-                                                                          'File[/etc/aptly.conf]',
+                                                                          'File[aptly_config_file]',
                                                                           'Exec[aptly_mirror_gpg-example]'
                                                                         ])
       }
@@ -110,7 +110,7 @@ describe 'aptly::mirror' do
                                                                         user: 'custom_user',
                                                                         require: [
                                                                           'Package[aptly]',
-                                                                          'File[/etc/aptly.conf]',
+                                                                          'File[aptly_config_file]',
                                                                           'Exec[aptly_mirror_gpg-example]'
                                                                         ])
       }

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -41,7 +41,7 @@ describe 'aptly::repo' do
       is_expected.to contain_exec('aptly_repo_create-example').with(command: %r{aptly -config \/etc\/aptly.conf repo create *example},
                                                                     unless: %r{aptly -config \/etc\/aptly.conf repo show example >\/dev\/null},
                                                                     user: 'root',
-                                                                    require: ['Package[aptly]', 'File[/etc/aptly.conf]'])
+                                                                    require: ['Package[aptly]', 'File[aptly_config_file]'])
     }
   end
 
@@ -56,7 +56,7 @@ describe 'aptly::repo' do
       is_expected.to contain_exec('aptly_repo_create-example').with(command: %r{aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example},
                                                                     unless: %r{aptly -config \/etc\/aptly.conf repo show example >\/dev\/null},
                                                                     user: 'root',
-                                                                    require: ['Package[aptly]', 'File[/etc/aptly.conf]'])
+                                                                    require: ['Package[aptly]', 'File[aptly_config_file]'])
     }
 
     context 'custom user' do
@@ -78,7 +78,7 @@ describe 'aptly::repo' do
         is_expected.to contain_exec('aptly_repo_create-example').with(command: %r{aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example},
                                                                       unless: %r{aptly -config \/etc\/aptly.conf repo show example >\/dev\/null},
                                                                       user: 'custom_user',
-                                                                      require: ['Package[aptly]', 'File[/etc/aptly.conf]'])
+                                                                      require: ['Package[aptly]', 'File[aptly_config_file]'])
       }
     end
   end
@@ -95,7 +95,7 @@ describe 'aptly::repo' do
         is_expected.to contain_exec('aptly_repo_create-example').with(command: %r{aptly -config \/etc\/aptly.conf repo create *-architectures="i386,amd64" *example},
                                                                       unless: %r{aptly -config \/etc\/aptly.conf repo show example >\/dev\/null},
                                                                       user: 'root',
-                                                                      require: ['Package[aptly]', 'File[/etc/aptly.conf]'])
+                                                                      require: ['Package[aptly]', 'File[aptly_config_file]'])
       }
     end
 
@@ -123,7 +123,7 @@ describe 'aptly::repo' do
       is_expected.to contain_exec('aptly_repo_create-example').with(command: %r{aptly -config \/etc\/aptly.conf repo create *-comment="example comment" *example},
                                                                     unless: %r{aptly -config \/etc\/aptly.conf repo show example >\/dev\/null},
                                                                     user: 'root',
-                                                                    require: ['Package[aptly]', 'File[/etc/aptly.conf]'])
+                                                                    require: ['Package[aptly]', 'File[aptly_config_file]'])
     }
   end
 
@@ -138,7 +138,7 @@ describe 'aptly::repo' do
       is_expected.to contain_exec('aptly_repo_create-example').with(command: %r{aptly -config \/etc\/aptly.conf repo create *-distribution="example_distribution" *example},
                                                                     unless: %r{aptly -config \/etc\/aptly.conf repo show example >\/dev\/null},
                                                                     user: 'root',
-                                                                    require: ['Package[aptly]', 'File[/etc/aptly.conf]'])
+                                                                    require: ['Package[aptly]', 'File[aptly_config_file]'])
     }
   end
 end


### PR DESCRIPTION
This allows the path to be configured to be any value but not fail
the require as the dependency is on the alias name, which does not change.